### PR TITLE
Remove extraneous space in charmap example

### DIFF
--- a/gbasmdev.tex
+++ b/gbasmdev.tex
@@ -1037,7 +1037,7 @@ CHARMAP "<heart>", 4
 CHARMAP " ", 0
 
 AbbaCabText:
-DB "ABBA CAB <heart>"
+DB "ABBA CAB<heart>"
 \end{code}
 
 will write 1,2,2,1,0,3,1,2,4 to the ROM. Note that the |CHARMAP| commands need to appear before the text definitions in the code. Also note that it is not possible to use a single |CHARMAP| command to specify the entire alphabet; one |CHARMAP| command is needed for each character.


### PR DESCRIPTION
This space is not present in the list of bytes below; it was removed because it showcases long symbols not separated by spaces.