### PR TITLE
Update RGBDS link to point to new website

### DIFF
--- a/gbasmdev.tex
+++ b/gbasmdev.tex
@@ -608,7 +608,7 @@ A good Game Boy emulator for game development is BGB, which is available here: \
 
 \section{About RGBDS}
 \label{rgbds}
-RGBDS is a Game Boy development system, and probably the compiler most commonly used today for making Game Boy games. It contains an assembler (which converts assembly code to binary), a linker (which converts one or more binaries into a Game Boy ROM file) as well as a "fixer" which fixes some common mistakes in the ROM file's header (like the checksum). You can find RGBDS and up-to-date install instructions for several operating systems are available here: \url{https://github.com/rednex/rgbds}
+RGBDS is a Game Boy development system, and probably the compiler most commonly used today for making Game Boy games. It contains an assembler (which converts assembly code to binary), a linker (which converts one or more binaries into a Game Boy ROM file) as well as a "fixer" which fixes some common mistakes in the ROM file's header (like the checksum). You can find RGBDS and up-to-date install instructions for several operating systems are available here: \url{https://rgbds.gbdev.io}
 
 \section{The GingerBread library}
 \label{gingerbread}


### PR DESCRIPTION
The new official homepage, including install instructions, is a brand new web site; link to that instead of the source code.