### PR TITLE
Clarify that "words" are unrelated to strings

### DIFF
--- a/gbasmdev.tex
+++ b/gbasmdev.tex
@@ -552,7 +552,7 @@ This chapter only provides a basic understanding of the more commonly used symbo
 \label{defdata}
 When you write code, it will be compiled into simple numbers to be stored in the ROM file. It is possible to generate arbitrary numbers into the ROM file, which can be used for many things that are not necessarily game code to be executed on the CPU. Since the Game Boy CPU is so limited, it is often a good idea to precompute any complicated calculations, if possible, and store the results in a table in the ROM, where the Game Boy can simply read the results instead of trying to compute them. This can be useful for things like trigonometric functions (to have an object move like a sine-wave across the screen, for example). Computing a sine-wave in real-time on the Game Boy CPU would probably be a lot slower than just having a pre-computed one which can be read from the ROM.
 
-To define such a table, it is a good idea to create a label at the top, so that the table can be referred to in code. There exist compiler commands for defining such data: |db| (to define data as bytes, 8-bit numbers) and |dw| (to define so-called “words”, meaning 16-bit numbers). For example
+To define such a table, it is a good idea to create a label at the top, so that the table can be referred to in code. There exist compiler commands for defining such data: |db| (to define data as bytes, 8-bit numbers) and |dw| (to define 16-bit numbers, called "words"; nothing to do with strings!). For example
 
 \begin{code}
 SomeTable:


### PR DESCRIPTION
This confused at least one reader, so make it more explicit.